### PR TITLE
Adds biome specific blocks for plains and desert biomes

### DIFF
--- a/stock-filters/ChirpVillage/BiomeSettings.py
+++ b/stock-filters/ChirpVillage/BiomeSettings.py
@@ -1,17 +1,28 @@
+blocks = {
+    'Cobblestone': (4,0),
+    'Oak Planks': (5, 0),
+    'Sandstone': (24,0),
+    'Chiseled Sandstone': (24, 1),
+    'Smooth Sandstone': (24, 2),
+    'Oak Fence': (85, 0),
+    'Stone Brick': (98, 0),
+    'Acacia Fence': (192, 0)
+}
+
 # biome names come from biome_types.py
 # material names are currently hardcoded
 # block id's can be found at https://minecraft-ids.grahamedgecombe.com/
 biomeSettings = {
 	"Plains": { # Default
-        "wall": (5, 0), # Oak Planks
-        "fence": (85, 0), # Oak Fence
-        "floor": (98,0), # Stone Brick
-        "road": (4,0) # Cobblestone
+        "wall": blocks['Oak Planks'],
+        "fence": blocks['Oak Fence'],
+        "floor": blocks['Stone Brick'],
+        "road": blocks['Cobblestone']
 	},
 	"Desert": {
-        "wall": (24, 1), # Chiseled Sandstone
-        "fence": (192, 0), # Acacia Fence
-        "floor": (24,0), # Sandstone
-        "road": (24,2) # Smooth Sandstone
+        "wall": blocks['Chiseled Sandstone'], 
+        "fence": blocks['Acacia Fence'],
+        "floor": blocks['Sandstone'],
+        "road": blocks['Smooth Sandstone']
 	}
 }

--- a/stock-filters/ChirpVillage/BiomeSettings.py
+++ b/stock-filters/ChirpVillage/BiomeSettings.py
@@ -3,15 +3,15 @@
 # block id's can be found at https://minecraft-ids.grahamedgecombe.com/
 biomeSettings = {
 	"Plains": { # Default
-        "wall_material": (5, 0), # Oak Planks
-        "fence_material": (85, 0), # Oak Fence
-        "floor_material": (98,0), # Stone Brick
-        "road_material": (4,0) # Cobblestone
+        "wall": (5, 0), # Oak Planks
+        "fence": (85, 0), # Oak Fence
+        "floor": (98,0), # Stone Brick
+        "road": (4,0) # Cobblestone
 	},
 	"Desert": {
-        "wall_material": (24, 1), # Chiseled Sandstone
-        "fence_material": (192, 0), # Acacia Fence
-        "floor_material": (24,0), # Sandstone
-        "road_material": (24,2) # Smooth Sandstone
+        "wall": (24, 1), # Chiseled Sandstone
+        "fence": (192, 0), # Acacia Fence
+        "floor": (24,0), # Sandstone
+        "road": (24,2) # Smooth Sandstone
 	}
 }

--- a/stock-filters/ChirpVillage/BiomeSettings.py
+++ b/stock-filters/ChirpVillage/BiomeSettings.py
@@ -1,0 +1,17 @@
+# biome names come from biome_types.py
+# material names are currently hardcoded
+# block id's can be found at https://minecraft-ids.grahamedgecombe.com/
+biomeSettings = {
+	"Plains": { # Default
+        "wall_material": (5, 0), # Oak Planks
+        "fence_material": (85, 0), # Oak Fence
+        "floor_material": (98,0), # Stone Brick
+        "road_material": (4,0) # Cobblestone
+	},
+	"Desert": {
+        "wall_material": (24, 1), # Chiseled Sandstone
+        "fence_material": (192, 0), # Acacia Fence
+        "floor_material": (24,0), # Sandstone
+        "road_material": (24,2) # Smooth Sandstone
+	}
+}

--- a/stock-filters/ChirpVillage/Block.py
+++ b/stock-filters/ChirpVillage/Block.py
@@ -4,6 +4,7 @@ class Block(object):
         self.x = x
         self.y = y
         self.height = height
+        self.biome_id = -1; #undefined by default, set in calculateBiomeMap of BlockUtils
 
     def get_x(self):
         return self.x

--- a/stock-filters/ChirpVillage/BlockUtils.py
+++ b/stock-filters/ChirpVillage/BlockUtils.py
@@ -12,19 +12,19 @@ def get_biome_name(biome):
 # getters for various biome specific blocks
 def get_wall_block(biome=1):
     biomeName = get_biome_name(biome)
-    return biomeSettings[biomeName]['wall_material'];
+    return biomeSettings[biomeName]['wall'];
 
 def get_floor_block(biome=1):
     biomeName = get_biome_name(biome)
-    return biomeSettings[biomeName]['floor_material'];
+    return biomeSettings[biomeName]['floor'];
 
 def get_fence_block(biome=1):
     biomeName = get_biome_name(biome)
-    return biomeSettings[biomeName]['fence_material'];
+    return biomeSettings[biomeName]['fence'];
 
 def get_road_block(biome=1):
     biomeName = get_biome_name(biome)
-    return biomeSettings[biomeName]['road_material'];
+    return biomeSettings[biomeName]['road'];
 
 # adds biome id's to all blocks in a provided surface object
 def calculateBiomeMap(level, surface):

--- a/stock-filters/ChirpVillage/BlockUtils.py
+++ b/stock-filters/ChirpVillage/BlockUtils.py
@@ -1,0 +1,39 @@
+from BiomeSettings import biomeSettings
+from pymclevel.biome_types import biome_types
+
+# gets the name of the biome, if the biome is not supported, returns 'Plains' biome
+def get_biome_name(biome):
+    biomeName = biome_types[biome]
+    if biomeName in biomeSettings:
+        return biomeName
+    else:
+        return 'Plains'
+
+# getters for various biome specific blocks
+def get_wall_block(biome=1):
+    biomeName = get_biome_name(biome)
+    return biomeSettings[biomeName]['wall_material'];
+
+def get_floor_block(biome=1):
+    biomeName = get_biome_name(biome)
+    return biomeSettings[biomeName]['floor_material'];
+
+def get_fence_block(biome=1):
+    biomeName = get_biome_name(biome)
+    return biomeSettings[biomeName]['fence_material'];
+
+def get_road_block(biome=1):
+    biomeName = get_biome_name(biome)
+    return biomeSettings[biomeName]['road_material'];
+
+# adds biome id's to all blocks in a provided surface object
+def calculateBiomeMap(level, surface):
+	for x in range(surface.x_start, surface.x_end):
+		for z in range(surface.z_start, surface.z_end):
+			chunk = level.getChunk(x / 16, z / 16)
+			chunkBiomeData = chunk.root_tag["Level"]["Biomes"].value
+			surface.surface_map[x - surface.x_start][z -
+			    surface.z_start].biome_id = chunkBiomeData[chunkIndexToBiomeDataIndexV2(x % 16, z % 16)]
+
+def chunkIndexToBiomeDataIndexV2(x, z):
+	return 255 - ((15 - x) + (15 - z) * 16)

--- a/stock-filters/ChirpVillage/Buildings/BasicBuilding.py
+++ b/stock-filters/ChirpVillage/Buildings/BasicBuilding.py
@@ -1,10 +1,12 @@
 from pymclevel import alphaMaterials, MCSchematic, MCLevel, BoundingBox
 import utilityFunctions
+import BlockUtils
 
 
 class BasicBuilding():
-    def __init__(self, level, box, block_id=98, block_type=0, height=5):
-        details = {'height': height, 'block': (block_id, block_type)}
+    def __init__(self, level, box, surface, block_id=98, block_type=0, height=5):
+        self.biome = surface.surface_map[0][0].biome_id
+        details = {'height': height, 'wall': BlockUtils.get_wall_block(self.biome)}
         self.construct_walls(level, box, details)
         self.construct_roof(level, box, details)
         self.construct_floor(level, box)
@@ -20,7 +22,7 @@ class BasicBuilding():
                                 level, (160, 3), x, y, z)
                         else:
                             utilityFunctions.setBlock(
-                                level, details['block'], x, y, z)
+                                level, details['wall'], x, y, z)
                     # Check if building is empty
                     elif level.blockAt(x, y, z) != 0:
                         utilityFunctions.setBlock(
@@ -36,10 +38,10 @@ class BasicBuilding():
         for x in range(box.minx, box.maxx):
             for z in range(box.minz, box.maxz):
                 utilityFunctions.setBlock(
-                    level, details['block'], x, box.miny + details['height'], z)
+                    level, details['wall'], x, box.miny + details['height'], z)
 
     def construct_floor(self, level, box):
         # This is where we build a floor
         for x in range(box.minx, box.maxx):
             for z in range(box.minz, box.maxz):
-                utilityFunctions.setBlock(level, (98, 0), x, box.miny, z)
+                utilityFunctions.setBlock(level, BlockUtils.get_floor_block(self.biome), x, box.miny, z)

--- a/stock-filters/ChirpVillageBuilder.py
+++ b/stock-filters/ChirpVillageBuilder.py
@@ -1,8 +1,8 @@
 from pymclevel import alphaMaterials, MCSchematic, MCLevel, BoundingBox
+from BasicBuilding import BasicBuilding 
+from Surface import Surface
 import utilityFunctions
-
-from ChirpVillage import BuildPlaneFinder
-
+import BlockUtils
 import os
 
 inputs = (
@@ -17,10 +17,12 @@ files = [
 
 
 def perform(level, box, options):
-    filename = os.getcwd() + default_path + 'ghast.schematic'
-    build_from_schematic(x=box.minx, y=box.miny, z=box.minz,
-                         filename=filename, level=level, box=box, options=options)
-    # BasicBuilding(level, box)
+    surface = Surface(box.minx, box.minz, box.maxx, box.maxz)
+	# calculateHeightMapAdv(level, surface)
+	# calculateSteepnessMap(surface)
+	# calculateWaterPlacement(level, surface)
+    BlockUtils.calculateBiomeMap(level, surface)
+    BasicBuilding(level, box, surface)
 
 
 def construct_building(level, box, type):


### PR DESCRIPTION
The basic functionality is working. I have simple getters for various blocks you may need. When you go to place a block and need the block id, you will use one of my getters.

Each getter takes a biome ID, I have already set the biome ID for every block in the Surface object, so all you need to do is pass in the .biome_id variable from the respective block (for roads it will be the block you replace, for building I suggest picking a single block so that the building does not change if it is on a biome intersection).

While the functionality is here, I still need to add abunch of blocks for people to use and add support for more biomes, but for now you can start using the functions!